### PR TITLE
Fix URL test bugs

### DIFF
--- a/test/models/url_test.rb
+++ b/test/models/url_test.rb
@@ -42,7 +42,6 @@ class UrlTest < Minitest::Test
   end
 
   def test_returns_all_response_times_for_given_url_sorted_by_length
-    skip
     setup_1
     url = Url.find(1)
     assert_equal [30, 20], url.list_url_response_times
@@ -61,8 +60,8 @@ class UrlTest < Minitest::Test
   end
 
   def test_three_most_popular_refers
-    skip
     setup_1
+    setup_referrers
     url = Url.find(1)
     assert_equal ["http://turing.io", "http://google.com"], url.three_most_popular_url_refers
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -64,6 +64,36 @@ module TestHelpers
     @payload_3 = Payload.create(@data3)
   end
 
+  def setup_referrers
+    refer1 = {
+      requested_at: "2013-02-18 22:38:28 -0700",
+      response_time: 50,
+      parameters: ["query"],
+      event_id: Event.where(name: "socialLogin").first_or_create.id,
+      ip_id: Ip.where(address: "67.29.38.211").first_or_create.id,
+      refer_id: Refer.where(address: "http://turing.io").first_or_create.id,
+      resolution_id: Resolution.where(width: "500", height: "500").first_or_create.id,
+      url_id: Url.where(address: "http://jumpstartlab.com").first_or_create.id,
+      user_environment_id: UserEnvironment.where(browser: "Chrome", os: "SOS").first_or_create.id,
+      request_type_id: RequestType.where(verb: "GET").first_or_create.id
+    }
+
+    refer2 = {
+      requested_at: "2012-02-16 22:38:28 -0700",
+      response_time: 20,
+      parameters: ["query"],
+      event_id: Event.where(name: "socialLogin").first_or_create.id,
+      ip_id: Ip.where(address: "65.29.38.211").first_or_create.id,
+      refer_id: Refer.where(address: "http://turing.io").first_or_create.id,
+      resolution_id: Resolution.where(width: "500", height: "500").first_or_create.id,
+      url_id: Url.where(address: "http://jumpstartlab.com").first_or_create.id,
+      user_environment_id: UserEnvironment.where(browser: "Chrome", os: "SOS").first_or_create.id,
+      request_type_id: RequestType.where(verb: "GET").first_or_create.id
+    }
+    Payload.create(refer1)
+    Payload.create(refer2)
+  end
+
   def client_setup
     post '/sources', {"identifier"=>"jumpstartlab",
           "rootUrl"=>"http://jumpstartlab.com"}


### PR DESCRIPTION
Feel free to merge now or wait until we're together. Fixed one test by adding more payloads (because otherwise it was a tie and could be sorted either way). Other skipped test was working both in pry and running as a test, and I don't know why it wouldn't work. Perhaps we changed something earlier and didn't realize it affected that test.